### PR TITLE
(MCOP-598) Add service provider for the service command

### DIFF
--- a/util/service/serviceservice.rb
+++ b/util/service/serviceservice.rb
@@ -6,25 +6,25 @@ module MCollective
       class ServiceService<Base
         def start
           status = service_command('start')
-          ret = status ? 'running' : 'stopped'
+          ret = status.success? ? 'running' : 'stopped'
           return {status: ret}
         end
 
         def stop
           status = service_command('stop')
-          ret = status ? 'stopped' : 'running'
+          ret = status.success? ? 'stopped' : 'running'
           return {status: ret}
         end
 
         def restart
           status = service_command('restart')
-          return 'running' if status
+          return 'running' if status.success?
           return 'stopped'
         end
 
         def status
           status = service_command('status')
-          return 'running' if status
+          return 'running' if status.success?
           return 'stopped'
         end
 

--- a/util/service/serviceservice.rb
+++ b/util/service/serviceservice.rb
@@ -1,3 +1,5 @@
+require 'open3'
+
 module MCollective
   module Util
     module Service
@@ -29,7 +31,8 @@ module MCollective
         private
         def service_command(cmd)
           servicecmd = @options[:servicecmd] || '/sbin/service'
-          system(servicecmd,@service,cmd)
+          _,status = Open3.capture2e(servicecmd,@service,cmd)
+          status
         end
       end
     end

--- a/util/service/serviceservice.rb
+++ b/util/service/serviceservice.rb
@@ -1,0 +1,37 @@
+module MCollective
+  module Util
+    module Service
+      class ServiceService<Base
+        def start
+          status = service_command('start')
+          ret = status ? 'running' : 'stopped'
+          return {status: ret}
+        end
+
+        def stop
+          status = service_command('stop')
+          ret = status ? 'stopped' : 'running'
+          return {status: ret}
+        end
+
+        def restart
+          status = service_command('restart')
+          return 'running' if status
+          return 'stopped'
+        end
+
+        def status
+          status = service_command('status')
+          return 'running' if status
+          return 'stopped'
+        end
+
+        private
+        def service_command(cmd)
+          servicecmd = @options[:servicecmd] || '/sbin/service'
+          system(servicecmd,@service,cmd)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Add a provider that calls the service command to start, stop, restart and
get process status.  The location of the service command defaults to
/sbin/service but is configurable by setting
plugin.service.service.servicecmd to the path of the command.
