### PR TITLE
Support @ as a valid character in service_name

### DIFF
--- a/validator/service_name.rb
+++ b/validator/service_name.rb
@@ -2,7 +2,7 @@ module MCollective
   module Validator
     class Service_nameValidator
       def self.validate(service_name)
-        raise("%s is not a valid service name" % service_name) unless !!(service_name =~ /\A^[a-zA-Z\.\-_\d]+$\z/)
+        raise("%s is not a valid service name" % service_name) unless !!(service_name =~ /\A^[a-zA-Z\.\-_\d@]+$\z/)
       end
     end
   end


### PR DESCRIPTION
Adds support for @ as a valid character in service_name validation. @ is useful with systemd services to run multiple instances of the same service.

I've tested this manually and confirmed I can query a service with @ in the name. Feel free to replace this change with a more robust fix.