### PR TITLE
(MCOP-594) service plugin unable to manage services with ':' in the name

### DIFF
--- a/spec/validator/service_name_validator.rb
+++ b/spec/validator/service_name_validator.rb
@@ -13,6 +13,8 @@ module MCollective
           Service_nameValidator.validate('rspec-service')
           Service_nameValidator.validate('rspec-service-1')
           Service_nameValidator.validate('rspec.service')
+          Service_nameValidator.validate('rspec@service')
+          Service_nameValidator.validate('rspec:service')
         end
         it 'should fail on a invalid service name' do
           expect{

--- a/validator/service_name.rb
+++ b/validator/service_name.rb
@@ -2,7 +2,7 @@ module MCollective
   module Validator
     class Service_nameValidator
       def self.validate(service_name)
-        raise("%s is not a valid service name" % service_name) unless !!(service_name =~ /\A^[a-zA-Z\.\-_\d@]+$\z/)
+        raise("%s is not a valid service name" % service_name) unless !!(service_name =~ /\A^[a-zA-Z\.\-_\d:@]+$\z/)
       end
     end
   end


### PR DESCRIPTION
This patch adds support for service names including ':' commonly used
for SMF on Solaris. It incorporates a patch previously carried and
shipped by Oracle.